### PR TITLE
'Is this compliant with Plan S' opens help modal

### DIFF
--- a/content/index.html
+++ b/content/index.html
@@ -66,7 +66,7 @@
         <h1>
           Is this compliant with
           <br>
-          <a href="https://www.coalition-s.org/">Plan S</a>
+          <a href="#" id="open_help_modal">Plan S</a>
           ?
         </h1>
         <div class="row row-inputs" id="inputs_plugin"></div>
@@ -306,6 +306,12 @@
 
   jct.d.gebi("explain_results").addEventListener("click", (e) => {
     jct.d.toggle_detailed_results();
+  })
+
+  jct.d.gebi('open_help_modal').addEventListener("click", (e) => {
+    e.preventDefault();
+    let modal = jct.d.gebi('modal_help');
+    modal.style.display = 'block';
   })
 
   </script>


### PR DESCRIPTION
Clicking on Plan S in 'Is this compliant with Plan S' opens the help modal.

Note: The help modal has links which do not refer to anything ([index.html#L206](https://github.com/CottageLabs/jct/blob/feature/208_link_to_help_modal/content/index.html#L206)). 