### PR TITLE
If user does not select a value on blur, set it to last searched value

### DIFF
--- a/static/clinput.js
+++ b/static/clinput.js
@@ -67,7 +67,7 @@ clinput.CLInput = class {
         if (this.selectedObject) {
             this.showSelectedObject()
         } else {
-            this._setInputValue("");
+            this._setInputValue(this.lastSearchValue);
         }
     }
 


### PR DESCRIPTION
This is a small fix for https://github.com/antleaf/jct-project/issues/292
