### PR TITLE
Bug fix/exact match on issn

### DIFF
--- a/static/jct.js
+++ b/static/jct.js
@@ -943,7 +943,7 @@ jct.setup = (manageUrl=true) => {
             autocomplete: "off"
         },
         options : function(text, callback) {
-            let pattern = /[0-9][0-9][0-9][0-9]-[0-9][0-9][0-9][0-9|x|X]/;
+            let pattern = /[0-9][0-9][0-9][0-9]-[0-9][0-9][0-9][0-9xX]/;
             if (pattern.test(text)) {
                 text = text.toUpperCase();
             } else {

--- a/static/jct.js
+++ b/static/jct.js
@@ -943,7 +943,10 @@ jct.setup = (manageUrl=true) => {
             autocomplete: "off"
         },
         options : function(text, callback) {
-            text = text.toLowerCase().replace(' of','').replace('the ','');
+            let pattern = /[0-9][0-9][0-9][0-9]-[0-9][0-9][0-9][0-9]((a-z|A-Z)?)/;
+            if (!pattern.test(text)) {
+                text = text.toLowerCase().replace(' of','').replace('the ','');
+            }
             if (text.length > 1) {
                 let ourcb = (xhr) => {
                     let js = JSON.parse(xhr.response);

--- a/static/jct.js
+++ b/static/jct.js
@@ -943,8 +943,10 @@ jct.setup = (manageUrl=true) => {
             autocomplete: "off"
         },
         options : function(text, callback) {
-            let pattern = /[0-9][0-9][0-9][0-9]-[0-9][0-9][0-9][0-9]((a-z|A-Z)?)/;
-            if (!pattern.test(text)) {
+            let pattern = /[0-9][0-9][0-9][0-9]-[0-9][0-9][0-9][0-9|x|X]/;
+            if (pattern.test(text)) {
+                text = text.toUpperCase();
+            } else {
                 text = text.toLowerCase().replace(' of','').replace('the ','');
             }
             if (text.length > 1) {

--- a/static/jct_plugin.js
+++ b/static/jct_plugin.js
@@ -1244,7 +1244,10 @@ jct.setup = (manageUrl=true) => {
             autocomplete: "off"
         },
         options : function(text, callback) {
-            text = text.toLowerCase().replace(' of','').replace('the ','');
+            let pattern = /[0-9][0-9][0-9][0-9]-[0-9][0-9][0-9][0-9]((a-z|A-Z)?)/;
+            if (!pattern.test(text)) {
+                text = text.toLowerCase().replace(' of','').replace('the ','');
+            }
             if (text.length > 1) {
                 let ourcb = (xhr) => {
                     let js = JSON.parse(xhr.response);

--- a/static/jct_plugin.js
+++ b/static/jct_plugin.js
@@ -1244,8 +1244,10 @@ jct.setup = (manageUrl=true) => {
             autocomplete: "off"
         },
         options : function(text, callback) {
-            let pattern = /[0-9][0-9][0-9][0-9]-[0-9][0-9][0-9][0-9]((a-z|A-Z)?)/;
-            if (!pattern.test(text)) {
+            let pattern = /[0-9][0-9][0-9][0-9]-[0-9][0-9][0-9][0-9|x|X]/;
+            if (pattern.test(text)) {
+                text = text.toUpperCase();
+            } else {
                 text = text.toLowerCase().replace(' of','').replace('the ','');
             }
             if (text.length > 1) {

--- a/static/jct_plugin.js
+++ b/static/jct_plugin.js
@@ -1244,7 +1244,7 @@ jct.setup = (manageUrl=true) => {
             autocomplete: "off"
         },
         options : function(text, callback) {
-            let pattern = /[0-9][0-9][0-9][0-9]-[0-9][0-9][0-9][0-9|x|X]/;
+            let pattern = /[0-9][0-9][0-9][0-9]-[0-9][0-9][0-9][0-9xX]/;
             if (pattern.test(text)) {
                 text = text.toUpperCase();
             } else {


### PR DESCRIPTION
PR for https://github.com/antleaf/jct-project/issues/356

* Match on ISSN. 
    * If a user is typing an ISSN, accept [0-9]{4}-[0-9]{3}[0-9xX]. 
    * The API expects an uppercase X, so convert to uppercase if is an ISSN.
* If it is not an ISSN, retain exiting code.

FYI - [the existing code](https://github.com/CottageLabs/jct/compare/bug_fix/exact_match_on_issn?expand=1#diff-dcd537356c8c27ef7fa14431a0aa41fd30ebe4ec10071b72d592c91501587dd3R950) converts the text typed by the user to lowercase and strips **' of'** and **'the'**
Note: The space before of and no space before the. This does not look correct to me. I have left this as is. It is the same behaviour for the other two fields as well. 