### PR TITLE
Beta logo removed

### DIFF
--- a/content/apidocs.md
+++ b/content/apidocs.md
@@ -23,16 +23,6 @@ td, th {
 
 The api is available at [{{< param apiURL >}}]({{< param apiURL >}}).
 
-<hr>
-
-**NOTE**
-
-We are offering access to the early version of the api to enable programmatic access to the data.
-This early version will be unsupported. Therefore we recommend that you do not integrate this API
-into your production systems until we transition out of beta. <br><br>
-The API is rate limited to 10 requests per second, with burst up to 6000, with delay. Exceeding the limit will result in 429.
-<hr>
-
 ## Request a compliance calculation
 
 To carry out a compliance calculation, you can make a get request, as detailed below.

--- a/layouts/partials/header-logo.html
+++ b/layouts/partials/header-logo.html
@@ -4,14 +4,12 @@
             {{- partial "header-title-image.html" . -}}
             {{ .Site.Params.pageTitle }}
         </h2>
-        {{- partial "header-beta.html" . -}}
     </div>
 {{ else }}
     <div class="header-logo">
         <h2 class="label">
             {{- partial "header-title-image.html" . -}}
             <a href="/">{{ .Site.Params.pageTitle }}</a>
-            {{- partial "header-beta.html" . -}}
         </h2>
     </div>
 {{ end }}


### PR DESCRIPTION
fixes https://github.com/antleaf/jct-project/issues/384

* Removed the beta label from the main page
* Removed the beta label from the static page headers
* Removed text on the API page that talks about the API support pre-beta